### PR TITLE
Implement ADR-006 plugin trust workflow

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,98 +1,113 @@
-# Plugin registry and trust model
+# Plugin registry and ADR-006 trust workflow
 
-This page shows the minimal, opt-in plugin registry shipped in ADR-006 and how
-to use it today, plus a short note about the planned full workflow and the
-limits of what plugins can (and cannot) do.
+ADR-006 introduced a conservative trust model for third-party plugins. The
+registry shipped in this repository now implements that model end-to-end:
 
-## Quick start (today)
+- Plugins are discovered either explicitly (manual registration) or via the
+  ``calibrated_explanations.plugins`` entry-point group.
+- Metadata is validated for required fields (name, version, provider,
+  capabilities, optional checksum) before registration succeeds.
+- Only trusted plugins participate in automated discovery. Trust can be granted
+  via :envvar:`CE_TRUST_PLUGIN` or programmatically with
+  :func:`calibrated_explanations.plugins.trust_plugin`.
+- Warnings are emitted the first time an untrusted plugin is seen so that users
+  understand how to opt-in.
+- Diagnostic helpers expose registered metadata via
+  :func:`calibrated_explanations.plugins.registry.list_plugins` (with the option
+  to include or filter untrusted entries).
+- Optional SHA256 checksums supplied by plugin authors are verified on a
+  best-effort basis to detect tampering.
 
-The repository includes a tiny example plugin used by tests at
-`tests/plugins/example_plugin.py`.
+The sections below show how to work with the registry safely.
 
-To register and trust a plugin at runtime you can do the following:
+## Quick start
 
 ```py
-from calibrated_explanations.plugins import registry
+from calibrated_explanations.plugins import registry, TRUST_ENV_VAR
 from tests.plugins.example_plugin import PLUGIN
 
-# Register the plugin (no side-effects beyond adding to the in-process registry)
-registry.register(PLUGIN)
+# Start from a clean slate (primarily useful in tests)
+registry.clear()
 
-# Optionally mark the plugin as trusted (controls discoverability via 'trusted' helpers)
-registry.trust_plugin(PLUGIN)
+# Registering validates metadata and records diagnostics. Untrusted plugins
+# trigger a one-time warning and are excluded from trusted discovery helpers.
+record = registry.register(PLUGIN)
+print(record.trusted)  # False by default for third-party plugins
 
-# List registered plugins
+# ``list_plugins`` returns immutable metadata dictionaries that include the
+# trusted flag, registration source, and checksum verification status.
 print(registry.list_plugins())
 
-# Find plugins that claim to support a model
-registry.find_for("supported-model")
-# Find trusted plugins only
-registry.find_for_trusted("supported-model")
+# Trusted discovery will skip untrusted plugins until you opt-in explicitly.
+assert registry.find_for_trusted("supported-model") == ()
 
-# Remove or untrust when needed
+# Trust can be granted at runtime...
+registry.trust_plugin(PLUGIN)
+assert registry.find_for_trusted("supported-model") == (PLUGIN,)
+
+# ...or via environment variable to support repeatable deployments.
+# export CE_TRUST_PLUGIN="tests.example_plugin"
+
+# When finished, remove or untrust plugins as needed.
 registry.untrust_plugin(PLUGIN)
 registry.unregister(PLUGIN)
 ```
 
-Notes:
+> **Tip:** ``CE_TRUST_PLUGIN`` accepts a comma- or path-separated list of plugin
+> names. Trust granted via the environment persists across registrations and
+> suppresses untrusted warnings.
 
-- `register` validates minimal metadata (see `plugins.base.validate_plugin_meta`) and will raise `ValueError` for malformed `plugin_meta`.
-- `trust_plugin` is an explicit opt-in step; the registry does not implicitly trust third-party code.
-- The registry is in-process and performs no automatic sandboxing or network calls.
+## Entry-point discovery
 
-Important: current status
-
-- The registry and helper APIs are available, but plugins are not yet integrated into the library's main explain flows by default. Registering a plugin adds it to the in-process registry and allows discovery via `find_for`/`find_for_trusted`, but it will not automatically be invoked by core expose functions unless you explicitly call the plugin's API. This minimizes risk while the trust model and discovery semantics are stabilized.
-
-Example: invoking a registered plugin explicitly
+Package authors can expose plugins via the ``calibrated_explanations.plugins``
+setuptools entry-point group. Consumers can load these entry points with:
 
 ```py
-# after register/ trust as above
-from calibrated_explanations.plugins import registry
+from calibrated_explanations.plugins import discover_entrypoint_plugins
 
-plugin = registry.find_for("supported-model")[0]
-# Call the plugin's explain method directly (explicit invocation) — this executes plugin code in-process
-result = plugin.explain("supported-model", X=[1, 2, 3])
-print(result)
+discovered = discover_entrypoint_plugins()
+print("Registered plugins:", discovered)
 ```
 
-## Planned full-support workflow (what will be available when ADR-006 is fully realized)
+Plugins discovered this way obey the same trust rules—metadata is recorded, but
+untrusted plugins are not returned by trusted discovery helpers until the user
+opts in.
 
-When the plugin model is fully supported the plan is to provide:
+## Metadata schema
 
-- Entry-point discovery: plugins can be discovered via the `calibrated_explanations.plugins`
-  setuptools entry point group or explicit programmatic registration.
-- Environment & CLI opt-in: a user can pre-authorize plugins using environment variables (e.g., `CE_TRUST_PLUGIN=<name>`) or a one-time programmatic trust API to allow safe, repeatable runs.
-- Richer metadata: plugins will expose structured metadata (name, version, provider, capabilities, optional checksum) to help discovery and basic compatibility checks.
-- Trust controls: `list_plugins(include_untrusted=True)` for diagnostics, and `find_for_trusted(...)` to only consider trusted plugins during automated discovery.
-- Documentation and examples: published examples showing how to write a plugin that implements explanation strategies and visualization adapters.
+Plugins must define a ``plugin_meta`` mapping with the following required keys:
 
-These features are deliberately conservative: the trust model is opt-in and the registry will emit actionable warnings when untrusted plugins are present.
+- ``schema_version`` (int)
+- ``name`` (str)
+- ``version`` (str)
+- ``provider`` (str)
+- ``capabilities`` (iterable of str)
 
-## What plugins are intended to do (capabilities)
+Optional key:
 
-Plugins are intended to be small, focused extension points such as:
+- ``checksum_sha256`` (str): 64-character hexadecimal digest of the plugin
+  module file. When provided, the registry recomputes the checksum to detect
+  mismatches and reports the status via ``checksum_status`` in the diagnostic
+  metadata.
 
-- Custom explanation strategies (implement `explain(model, X, **kwargs)` and return either a domain `Explanation` or a legacy explanation dict).
-- Lightweight visualization adapters or renderers (return `PlotSpec` or render directly when requested by caller).
-- Small helper adapters that adapt model types not supported by the core library.
+If metadata is malformed a :class:`ValueError` is raised during registration.
 
-Each plugin should declare its capabilities via `plugin_meta["capabilities"]` so callers can filter available plugins by the features they need.
+## Security considerations
 
-## Limits and security considerations (important)
+- **Trust is explicit.** Loading or registering a plugin executes arbitrary
+  Python code. Trust flags do not sandbox execution; they simply gate automated
+  discovery helpers and remind users to opt in intentionally.
+- **Warnings are actionable.** The first encounter with an untrusted plugin
+  emits a warning including the environment variable and API call required to
+  trust it. Subsequent registrations of the same plugin do not spam additional
+  warnings.
+- **Checksum verification is best-effort.** If a checksum cannot be computed
+  (for example, when a module has no ``__file__`` attribute) the registry marks
+  the status as ``"unverified"`` but still records the plugin metadata.
+- **Built-in plugins auto-trust.** Plugins whose provider is
+  ``"calibrated_explanations"`` (or that are explicitly registered with
+  ``built_in=True``) are trusted automatically so that official plugins work out
+  of the box.
 
-- In-process execution only: plugins run in the same Python process as the host library. There is no sandboxing. A plugin can execute arbitrary Python code and therefore may access or modify process state.
-- Coarse trust flag: the `trusted` marker is an explicit opt-in but it is not a security boundary. Treat it as a usability guard, not a sandbox.
-- Metadata validation only: the registry validates only minimal metadata (presence and basic types). It does not verify code provenance or cryptographic signatures. Optional checksum fields may be supported later but will be best-effort.
-- API surface constraints: plugins are limited to the public plugin Protocol (see `calibrated_explanations.plugins.base.ExplainerPlugin`) — they cannot alter private internals unless those internals are explicitly exposed by the library's plugin hooks or public APIs.
-- Schema compatibility: explanation outputs should conform to the documented Explanation schema (schema v1) or to the legacy shapes accepted by adapters; otherwise consumers may fail downstream serializers or visualizers.
-
-## Recommended practices for plugin authors
-
-- Keep plugins focused and small (one responsibility: explainers vs visualizers).
-- Declare capability metadata and a stable `name` and `version` in `plugin_meta`.
-- Avoid side-effects at import time; prefer lazy initialization and explicit `register` calls.
-- Provide a small test-suite or smoke test so consumers can validate behavior.
-
----
-For more on the ADR and the trust model, see `improvement_docs/adrs/ADR-006-plugin-registry-trust-model.md`.
+For the rationale behind these decisions, see
+``improvement_docs/adrs/ADR-006-plugin-registry-trust-model.md``.

--- a/src/calibrated_explanations/plugins/__init__.py
+++ b/src/calibrated_explanations/plugins/__init__.py
@@ -10,13 +10,21 @@ Only use plugins you trust. This API is opt-in and intentionally explicit.
 
 from . import registry  # re-export module for convenience
 from .base import ExplainerPlugin, validate_plugin_meta  # noqa: F401
-from .registry import find_for_trusted, trust_plugin, untrust_plugin  # noqa: F401
+from .registry import (  # noqa: F401
+    TRUST_ENV_VAR,
+    discover_entrypoint_plugins,
+    find_for_trusted,
+    trust_plugin,
+    untrust_plugin,
+)
 
 __all__ = [
     "ExplainerPlugin",
     "validate_plugin_meta",
     "registry",
+    "TRUST_ENV_VAR",
     "trust_plugin",
     "untrust_plugin",
     "find_for_trusted",
+    "discover_entrypoint_plugins",
 ]

--- a/src/calibrated_explanations/plugins/base.py
+++ b/src/calibrated_explanations/plugins/base.py
@@ -16,7 +16,7 @@ This mirrors ADR-006 minimal capability metadata and keeps behavior opt-in.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Protocol
+from typing import Any, Dict, Iterable, Protocol
 
 
 class ExplainerPlugin(Protocol):
@@ -40,16 +40,50 @@ class ExplainerPlugin(Protocol):
 def validate_plugin_meta(meta: Dict[str, Any]) -> None:
     """Validate minimal plugin metadata.
 
-    Required keys: schema_version (int), capabilities (list[str]), name (str)
+    Required keys (ADR-006):
+    - ``schema_version`` (int)
+    - ``name`` (str, non-empty)
+    - ``version`` (str, non-empty)
+    - ``provider`` (str, non-empty)
+    - ``capabilities`` (iterable of ``str``)
+
+    Optional keys:
+    - ``checksum_sha256`` (64-character hexadecimal string)
     """
 
     if not isinstance(meta, dict):
         raise ValueError("plugin_meta must be a dict")
-    for key, typ in ("schema_version", int), ("capabilities", list), ("name", str):
+
+    required_types = {
+        "schema_version": int,
+        "name": str,
+        "version": str,
+        "provider": str,
+    }
+    for key, typ in required_types.items():
         if key not in meta:
             raise ValueError(f"plugin_meta missing required key: {key}")
         if not isinstance(meta[key], typ):
             raise ValueError(f"plugin_meta[{key!r}] must be {typ.__name__}")
+        if isinstance(meta[key], str) and not meta[key].strip():
+            raise ValueError(f"plugin_meta[{key!r}] must be a non-empty string")
+
+    if "capabilities" not in meta:
+        raise ValueError("plugin_meta missing required key: capabilities")
+
+    capabilities = meta["capabilities"]
+    if not isinstance(capabilities, Iterable) or isinstance(capabilities, (str, bytes)):
+        raise ValueError("plugin_meta['capabilities'] must be an iterable of strings")
+    if not all(isinstance(cap, str) and cap.strip() for cap in capabilities):
+        raise ValueError("plugin_meta['capabilities'] entries must be non-empty strings")
+
+    checksum = meta.get("checksum_sha256")
+    if checksum is not None:
+        if not isinstance(checksum, str):
+            raise ValueError("plugin_meta['checksum_sha256'] must be a string if provided")
+        hex_value = checksum.strip().lower()
+        if len(hex_value) != 64 or any(ch not in "0123456789abcdef" for ch in hex_value):
+            raise ValueError("plugin_meta['checksum_sha256'] must be a 64-character hex digest")
 
 
 __all__ = ["ExplainerPlugin", "validate_plugin_meta"]

--- a/src/calibrated_explanations/plugins/registry.py
+++ b/src/calibrated_explanations/plugins/registry.py
@@ -1,91 +1,251 @@
-"""Plugin registry (ADR-006 minimal, opt-in).
-
-Explicit, in-process registry for explainer plugins. Users must call `register`
-to add plugins. Discovery is local to this process; there is no I/O or import
-side-effects here to reduce risk.
-"""
+"""Plugin registry implementing ADR-006 trust model."""
 
 from __future__ import annotations
 
-import contextlib
-from typing import Any, List, Tuple
+import hashlib
+import inspect
+import os
+import warnings
+from copy import deepcopy
+from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Tuple
 
 from .base import ExplainerPlugin, validate_plugin_meta
 
-_REGISTRY: List[ExplainerPlugin] = []
-
-# Minimal trust store: only plugins explicitly trusted by the user are allowed
-# to be returned by discovery helpers when trust is requested.
-_TRUSTED: List[ExplainerPlugin] = []
+TRUST_ENV_VAR = "CE_TRUST_PLUGIN"
+_BUILTIN_PROVIDER = "calibrated_explanations"
+_ENTRYPOINT_GROUP = "calibrated_explanations.plugins"
 
 
-def register(plugin: ExplainerPlugin) -> None:
-    """Register a plugin after minimal metadata validation.
+@dataclass
+class PluginRecord:
+    """Internal record storing plugin object and metadata."""
 
-    Notes: Registering a plugin executes third-party code at import-time.
-    Only register trusted plugins.
+    plugin: ExplainerPlugin
+    meta: Dict[str, Any]
+    source: str
+    trusted: bool
+    checksum_status: str
+
+
+_REGISTRY: MutableMapping[str, PluginRecord] = {}
+_WARNED_UNTRUSTED: set[str] = set()
+
+
+def register(
+    plugin: ExplainerPlugin,
+    *,
+    source: str = "manual",
+    built_in: bool | None = None,
+) -> PluginRecord:
+    """Register a plugin instance and return its :class:`PluginRecord`.
+
+    Metadata is validated according to ADR-006. If the plugin is not trusted it
+    remains discoverable via :func:`list_plugins` but will not be returned by
+    :func:`find_for` when ``trusted_only`` is ``True``.
     """
 
     meta = getattr(plugin, "plugin_meta", None)
     validate_plugin_meta(meta)
-    if plugin in _REGISTRY:
-        return
-    _REGISTRY.append(plugin)
+    meta_copy = deepcopy(meta)
+    meta_copy["capabilities"] = tuple(meta_copy["capabilities"])
+    name = meta_copy["name"]
+
+    prior_record = _REGISTRY.get(name)
+
+    trusted_names = _trusted_names_from_env()
+    provider = meta_copy["provider"]
+    is_builtin = bool(built_in) if built_in is not None else provider == _BUILTIN_PROVIDER
+
+    trusted = is_builtin or name in trusted_names
+    if prior_record and prior_record.trusted:
+        trusted = True
+
+    checksum_status = _verify_checksum(plugin, meta_copy)
+
+    record = PluginRecord(
+        plugin=plugin,
+        meta=meta_copy,
+        source=source,
+        trusted=trusted,
+        checksum_status=checksum_status,
+    )
+    _REGISTRY[name] = record
+
+    if not record.trusted:
+        _emit_untrusted_warning(record)
+
+    return record
 
 
-def unregister(plugin: ExplainerPlugin) -> None:
-    """Remove a plugin if present."""
+def unregister(identifier: str | ExplainerPlugin) -> None:
+    """Remove a plugin from the registry (trusted state included)."""
 
-    with contextlib.suppress(ValueError):
-        _REGISTRY.remove(plugin)
-    with contextlib.suppress(ValueError):
-        _TRUSTED.remove(plugin)
+    name = _resolve_name(identifier)
+    _REGISTRY.pop(name, None)
+    _WARNED_UNTRUSTED.discard(name)
 
 
 def clear() -> None:
-    """Clear all registered plugins (testing convenience)."""
+    """Clear all registered plugins."""
 
     _REGISTRY.clear()
+    _WARNED_UNTRUSTED.clear()
 
 
-def list_plugins() -> Tuple[ExplainerPlugin, ...]:
-    """Return a snapshot of registered plugins."""
+def list_plugins(*, include_untrusted: bool = True) -> Tuple[Mapping[str, Any], ...]:
+    """Return plugin metadata records.
 
-    return tuple(_REGISTRY)
+    Each record contains the plugin metadata plus derived fields:
 
-
-def trust_plugin(plugin: ExplainerPlugin) -> None:
-    """Mark an already-registered plugin as trusted.
-
-    Trust is an explicit, opt-in operation. The function validates metadata
-    before adding to the trusted list. Only trusted plugins will be returned
-    by :func:`find_for` when `trusted_only=True` is passed.
+    - ``trusted``: whether the plugin is currently trusted
+    - ``source``: registration source (manual, entry point, etc.)
+    - ``checksum_status``: ``ok``, ``mismatch``, ``unverified``, or ``not-provided``
     """
-    if plugin not in _REGISTRY:
-        raise ValueError("Plugin must be registered before it can be trusted")
-    meta = getattr(plugin, "plugin_meta", None)
-    validate_plugin_meta(meta)
-    if plugin in _TRUSTED:
-        return
-    _TRUSTED.append(plugin)
+
+    records: Iterable[PluginRecord]
+    if include_untrusted:
+        records = _REGISTRY.values()
+    else:
+        records = (record for record in _REGISTRY.values() if record.trusted)
+    return tuple(_public_record(record) for record in records)
 
 
-def untrust_plugin(plugin: ExplainerPlugin) -> None:
-    """Remove a plugin from the trusted set if present."""
-    with contextlib.suppress(ValueError):
-        _TRUSTED.remove(plugin)
+def trust_plugin(identifier: str | ExplainerPlugin) -> None:
+    """Mark a plugin as trusted by name or plugin object."""
+
+    name = _resolve_name(identifier)
+    record = _REGISTRY.get(name)
+    if record is None:
+        raise ValueError(f"Plugin '{name}' is not registered")
+    record.trusted = True
 
 
-def find_for(model: Any) -> Tuple[ExplainerPlugin, ...]:
-    """Find plugins that declare support for the given model."""
+def untrust_plugin(identifier: str | ExplainerPlugin) -> None:
+    """Mark a plugin as untrusted if present."""
 
-    return tuple(p for p in _REGISTRY if _safe_supports(p, model))
+    name = _resolve_name(identifier)
+    record = _REGISTRY.get(name)
+    if record is not None:
+        record.trusted = False
+
+
+def find_for(model: Any, *, trusted_only: bool = False) -> Tuple[ExplainerPlugin, ...]:
+    """Return plugins that report support for ``model``.
+
+    ``trusted_only`` defaults to ``False`` to allow manual experimentation, but
+    callers that rely on ADR-006 guarantees should pass ``trusted_only=True`` or
+    use :func:`find_for_trusted`.
+    """
+
+    records: Iterable[PluginRecord]
+    if trusted_only:
+        records = (record for record in _REGISTRY.values() if record.trusted)
+    else:
+        records = _REGISTRY.values()
+    return tuple(record.plugin for record in records if _safe_supports(record.plugin, model))
 
 
 def find_for_trusted(model: Any) -> Tuple[ExplainerPlugin, ...]:
-    """Find trusted plugins that declare support for the given model."""
+    """Return trusted plugins that support ``model``."""
 
-    return tuple(p for p in _TRUSTED if _safe_supports(p, model))
+    return find_for(model, trusted_only=True)
+
+
+def discover_entrypoint_plugins(group: str = _ENTRYPOINT_GROUP) -> Tuple[str, ...]:
+    """Load plugins exposed via the setuptools entry point group.
+
+    Returns a tuple of plugin names that were discovered. Untrusted plugins are
+    still registered (so that metadata is visible) but remain untrusted until the
+    user opts in via :func:`trust_plugin` or :envvar:`CE_TRUST_PLUGIN`.
+    """
+
+    try:
+        entry_points = importlib_metadata.entry_points()
+    except Exception as exc:  # pragma: no cover - importlib metadata failure is rare
+        warnings.warn(f"Failed to load plugin entry points: {exc}")
+        return ()
+
+    if hasattr(entry_points, "select"):
+        selected = entry_points.select(group=group)
+    else:  # pragma: no cover - Python <3.10 compatibility
+        selected = [ep for ep in entry_points if ep.group == group]
+
+    discovered: list[str] = []
+    for entry_point in selected:
+        try:
+            plugin = entry_point.load()
+        except Exception as exc:  # pragma: no cover - plugin import failures
+            warnings.warn(f"Failed to load plugin '{entry_point.name}': {exc}")
+            continue
+        record = register(plugin, source=f"entry_point:{entry_point.name}")
+        discovered.append(record.meta["name"])
+    return tuple(discovered)
+
+
+def _public_record(record: PluginRecord) -> Dict[str, Any]:
+    result = dict(record.meta)
+    result.update(
+        {
+            "trusted": record.trusted,
+            "source": record.source,
+            "checksum_status": record.checksum_status,
+        }
+    )
+    return result
+
+
+def _resolve_name(identifier: str | ExplainerPlugin) -> str:
+    if isinstance(identifier, str):
+        return identifier
+    meta = getattr(identifier, "plugin_meta", None)
+    if isinstance(meta, dict) and "name" in meta:
+        return str(meta["name"])
+    raise ValueError("Cannot resolve plugin name from identifier")
+
+
+def _trusted_names_from_env() -> set[str]:
+    raw = os.getenv(TRUST_ENV_VAR, "")
+    if not raw:
+        return set()
+    separators = {",", os.pathsep}
+    for sep in list(separators):
+        raw = raw.replace(sep, ",")
+    names = {chunk.strip() for chunk in raw.split(",") if chunk.strip()}
+    return names
+
+
+def _emit_untrusted_warning(record: PluginRecord) -> None:
+    name = record.meta["name"]
+    if name in _WARNED_UNTRUSTED:
+        return
+    _WARNED_UNTRUSTED.add(name)
+    warnings.warn(
+        (
+            f"Plugin '{name}' from provider '{record.meta['provider']}' is not trusted. "
+            f"Set {TRUST_ENV_VAR}={name} or call trust_plugin('{name}') to opt in."
+        ),
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def _verify_checksum(plugin: ExplainerPlugin, meta: Mapping[str, Any]) -> str:
+    expected = meta.get("checksum_sha256")
+    if not expected:
+        return "not-provided"
+
+    module = inspect.getmodule(plugin.__class__)
+    path = getattr(module, "__file__", None) if module else None
+    if not path:
+        return "unverified"
+    try:
+        with open(path, "rb") as fh:
+            digest = hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return "unverified"
+    return "ok" if digest == expected.lower() else "mismatch"
 
 
 def _safe_supports(plugin: ExplainerPlugin, model: Any) -> bool:
@@ -96,6 +256,7 @@ def _safe_supports(plugin: ExplainerPlugin, model: Any) -> bool:
 
 
 __all__ = [
+    "TRUST_ENV_VAR",
     "register",
     "unregister",
     "clear",
@@ -104,4 +265,6 @@ __all__ = [
     "untrust_plugin",
     "find_for",
     "find_for_trusted",
+    "discover_entrypoint_plugins",
 ]
+

--- a/tests/plugins/example_plugin.py
+++ b/tests/plugins/example_plugin.py
@@ -11,7 +11,13 @@ from typing import Any
 
 
 class ExamplePlugin:
-    plugin_meta = {"schema_version": 1, "capabilities": ["explain"], "name": "tests.example_plugin"}
+    plugin_meta = {
+        "schema_version": 1,
+        "capabilities": ["explain"],
+        "name": "tests.example_plugin",
+        "version": "1.0.0-test",
+        "provider": "calibrated_explanations.tests",
+    }
 
     def supports(self, model: Any) -> bool:
         # Support a simple sentinel model value or a dict marker for tests

--- a/tests/unit/core/test_fast_units.py
+++ b/tests/unit/core/test_fast_units.py
@@ -31,7 +31,13 @@ def test_make_key_is_deterministic():
 
 
 class _FakePlugin:
-    plugin_meta = {"schema_version": 1, "capabilities": ["explain"], "name": "fake"}
+    plugin_meta = {
+        "schema_version": 1,
+        "capabilities": ["explain"],
+        "name": "fake",
+        "version": "0.0.0",
+        "provider": "tests",
+    }
 
     def supports(self, model):
         return True
@@ -44,13 +50,14 @@ def test_plugin_registry_register_and_find():
     registry.clear()
     p = _FakePlugin()
     registry.register(p)
-    assert p in registry.list_plugins()
-    # find_for should return our plugin for any model
-    found = registry.find_for(object())
-    assert any(isinstance(x, _FakePlugin.__class__) or x is p for x in found)
-    registry.untrust_plugin(p)  # safe if not trusted
+    assert registry.list_plugins()[0]["name"] == "fake"
+    registry.trust_plugin(p)
+    # find_for should return our plugin for any model once trusted
+    found = registry.find_for_trusted(object())
+    assert found == (p,)
+    registry.untrust_plugin(p)
     registry.unregister(p)
-    assert p not in registry.list_plugins()
+    assert registry.list_plugins() == ()
 
 
 def test_plotspec_dataclasses_roundtrip():

--- a/tests/unit/core/test_plugin_registry.py
+++ b/tests/unit/core/test_plugin_registry.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+import pytest
+
 from calibrated_explanations.plugins import registry
 
 
@@ -7,7 +9,9 @@ class DummyPlugin:
     plugin_meta: Dict[str, Any] = {
         "schema_version": 1,
         "capabilities": ["explain"],
-        "name": "dummy",
+        "name": "dummy-alt",
+        "version": "0.0.1",
+        "provider": "tests",
     }
 
     def supports(self, model: Any) -> bool:
@@ -21,20 +25,22 @@ def test_register_and_find_for():
     registry.clear()
     p = DummyPlugin()
     registry.register(p)
-    assert p in registry.list_plugins()
 
     class M:
         is_dummy = True
 
-    found = registry.find_for(M())
-    assert p in found
+    assert registry.find_for_trusted(M()) == ()
+
+    registry.trust_plugin(p)
+    found = registry.find_for_trusted(M())
+    assert found == (p,)
 
 
 def test_register_validation():
     registry.clear()
 
     class Bad:
-        plugin_meta = {"name": "bad", "capabilities": ["explain"]}  # missing schema_version
+        plugin_meta = {"name": "bad", "capabilities": ["explain"]}
 
         def supports(self, model: Any) -> bool:
             return False
@@ -42,22 +48,18 @@ def test_register_validation():
         def explain(self, model: Any, X: Any, **kwargs: Any) -> Any:
             return None
 
-    try:
+    with pytest.raises(ValueError):
         registry.register(Bad())
-    except ValueError as e:
-        assert "schema_version" in str(e)
-    else:
-        assert False, "ValueError expected for missing schema_version"
 
 
 def test_unregister():
     registry.clear()
 
     class P(DummyPlugin):
-        pass
+        plugin_meta = DummyPlugin.plugin_meta | {"name": "dummy-unregister"}
 
     p = P()
     registry.register(p)
-    assert p in registry.list_plugins()
+    assert registry.list_plugins()[0]["name"] == p.plugin_meta["name"]
     registry.unregister(p)
-    assert p not in registry.list_plugins()
+    assert registry.list_plugins() == ()

--- a/tests/unit/core/test_plugins_registry.py
+++ b/tests/unit/core/test_plugins_registry.py
@@ -1,48 +1,56 @@
+import hashlib
 import importlib
 import types
 
 import pytest
 
 from calibrated_explanations.plugins import registry
+from calibrated_explanations.plugins.registry import TRUST_ENV_VAR
 
 
-def test_register_and_find_example_plugin(tmp_path, monkeypatch):
-    # Instead of writing to disk, import the packaged test plugin shipped under tests/plugins
+def test_register_requires_trust():
     mod = importlib.import_module("tests.plugins.example_plugin")
     plugin = getattr(mod, "PLUGIN")
 
-    # Start from a clean registry
     registry.clear()
 
-    # Register and find
-    registry.register(plugin)
-    all_plugins = registry.list_plugins()
-    assert plugin in all_plugins
+    with pytest.warns(UserWarning) as warn_record:
+        record = registry.register(plugin, source="unit-test")
 
-    # find_for should return plugin for supported models
-    found = registry.find_for("supported-model")
-    assert plugin in found
+    assert not record.trusted
+    assert warn_record[0].message.args[0].startswith("Plugin 'tests.example_plugin'")
 
-    # Not supported model should return empty
-    assert registry.find_for("unsupported") == ()
+    info = registry.list_plugins()
+    assert len(info) == 1
+    entry = info[0]
+    assert entry["name"] == plugin.plugin_meta["name"]
+    assert entry["trusted"] is False
+    assert entry["source"] == "unit-test"
 
-    # Mark as trusted and ensure trusted discovery returns it
+    assert registry.list_plugins(include_untrusted=False) == ()
+    assert registry.find_for_trusted("supported-model") == ()
+
+    # Manual trust enables discovery
     registry.trust_plugin(plugin)
     trusted = registry.find_for_trusted("supported-model")
-    assert plugin in trusted
+    assert trusted and trusted[0] is plugin
 
-    # Untrust and ensure it's not returned by trusted finder
+    # find_for with trusted_only defaults to False to support manual usage
+    all_found = registry.find_for("supported-model")
+    assert plugin in all_found
+
+    # Untrust removes from trusted discovery but keeps metadata visible
     registry.untrust_plugin(plugin)
-    assert plugin not in registry.find_for_trusted("supported-model")
+    assert registry.find_for_trusted("supported-model") == ()
+    assert registry.list_plugins()[0]["trusted"] is False
 
-    # Unregister removes the plugin
     registry.unregister(plugin)
-    assert plugin not in registry.list_plugins()
+    assert registry.list_plugins() == ()
 
 
 def test_validate_plugin_meta_rejects_bad_meta():
     class BadPlugin:
-        plugin_meta = {"capabilities": ["explain"]}  # missing name and schema_version
+        plugin_meta = {"capabilities": ["explain"], "name": "bad"}
 
         def supports(self, model):
             return False
@@ -55,7 +63,13 @@ def test_validate_plugin_meta_rejects_bad_meta():
 
 
 class DummyPlugin:
-    plugin_meta = {"schema_version": 1, "capabilities": ["explain"], "name": "dummy"}
+    plugin_meta = {
+        "schema_version": 1,
+        "capabilities": ["explain"],
+        "name": "dummy",
+        "version": "0.1.0",
+        "provider": "tests",
+    }
 
     def supports(self, model):
         return getattr(model, "is_dummy", False)
@@ -64,26 +78,51 @@ class DummyPlugin:
         return {"explained": True}
 
 
-def test_register_and_trust_flow(tmp_path):
-    p = DummyPlugin()
-    # ensure clean start
+def test_register_and_trust_flow(monkeypatch):
     registry.clear()
+    p = DummyPlugin()
+
     registry.register(p)
-    assert p in registry.list_plugins()
 
-    # trusting unregistered plugin raises
     with pytest.raises(ValueError):
-        registry.trust_plugin(object())
+        registry.trust_plugin("unknown")
 
-    # trust and find
     registry.trust_plugin(p)
     trusted = registry.find_for_trusted(types.SimpleNamespace(is_dummy=True))
-    assert p in trusted
+    assert trusted == (p,)
 
-    # untrust works
     registry.untrust_plugin(p)
-    trusted2 = registry.find_for_trusted(types.SimpleNamespace(is_dummy=True))
-    assert p not in trusted2
+    assert registry.find_for_trusted(types.SimpleNamespace(is_dummy=True)) == ()
 
-    # cleanup
     registry.unregister(p)
+
+
+def test_env_trust_enables_auto_trust(monkeypatch):
+    registry.clear()
+    p = DummyPlugin()
+    monkeypatch.setenv(TRUST_ENV_VAR, p.plugin_meta["name"])
+
+    record = registry.register(p, source="env-test")
+    assert record.trusted is True
+    assert registry.list_plugins(include_untrusted=False)[0]["trusted"] is True
+
+
+def test_checksum_status(monkeypatch, tmp_path):
+    registry.clear()
+
+    class ChecksumPlugin(DummyPlugin):
+        plugin_meta = DummyPlugin.plugin_meta | {"name": "checksum", "version": "0.2.0"}
+
+    plugin = ChecksumPlugin()
+    module_path = __file__
+
+    with open(module_path, "rb") as fh:
+        digest = hashlib.sha256(fh.read()).hexdigest()
+
+    plugin.plugin_meta["checksum_sha256"] = digest
+    record = registry.register(plugin)
+    assert record.checksum_status == "ok"
+
+    plugin.plugin_meta["checksum_sha256"] = "0" * 64
+    record2 = registry.register(plugin)
+    assert record2.checksum_status == "mismatch"


### PR DESCRIPTION
## Summary
- enforce the ADR-006 metadata contract, including provider/version fields and optional checksum validation
- overhaul the plugin registry to honour trusted flags, environment opt-ins, entry-point discovery, and diagnostic metadata
- refresh documentation, the example plugin, and unit tests to cover the trust workflow and checksum verification

## Testing
- PYTHONPATH=src pytest tests/unit/core/test_plugins_registry.py tests/unit/core/test_plugin_registry.py tests/unit/core/test_fast_units.py

------
https://chatgpt.com/codex/tasks/task_b_68e2232608ac83299861db86a3769a36

## Summary by Sourcery

Enforce the ADR-006 metadata contract and overhaul the plugin registry to implement an explicit trust workflow featuring manual and environment-variable opt-in, entry-point discovery, untrusted warnings, and checksum verification

New Features:
- Implement ADR-006 plugin trust workflow with manual and environment-variable opt-in
- Add setuptools entry-point discovery for third-party plugins
- Introduce optional SHA256 checksum verification for plugin modules

Enhancements:
- Redesign registry to store plugin records with metadata, source, trust state, and checksum status
- Enforce extended plugin_meta schema requiring provider and version fields and validate capabilities iterable
- Update list_plugins, find_for, trust_plugin, and untrust_plugin to honor trust flags and include diagnostic metadata

Documentation:
- Refresh plugin documentation to describe ADR-006 trust workflow, metadata schema, entry-point discovery, and security considerations

Tests:
- Extend unit tests to cover trust opt-in, environment‐variable trust, checksum status, and entry-point registration